### PR TITLE
Documentation de l'environnement de développement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
+gem 'github-pages'
 gem 'jekyll-seo-tag'
+gem 'jekyll-sitemap'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+## Générer le site localement avec Jekyll
+
+### Prérequis
+
+[Installer ruby et Jekyll](https://jekyllrb.com/docs/installation/)
+
+### Installer les dépendances du projet
+
+Se déplacer à la racine du projet puis
+
+```sh
+bundle install
+```
+
+### Démarrer le serveur de développement
+
+```sh
+bundle exec jekyll serve --safe
+```
+
+> `bundle exec` vous assure que la version de jekyll utilisée est celle spécifiée dans le fichier `Gemfile.lock`.
+
+> L'option `--safe` permet d'avoir le même comportement que sur les serveurs de build de Github Pages. Ainsi pas de surprise lors du déploiement.
+
+```
+Generating... 
+                   done in 0.124 seconds.
+Auto-regeneration: enabled for '/home/emak/code/societenumerique.github.io'
+Server address:    http://127.0.0.1:4000
+Server running...  press ctrl-c to stop.
+```
+
+Visiter l'url : <http://localhost:4000>
+
+> Le site est généré dans le dossier `_site` qui est ignoré par git.
+
+> Le site est automatiquement regénéré lorsqu'un fichier source est édité (`_layouts`, `_includes`, `_topics`, etc). Il suffit de rafraichir la page pour voir les changements.
+
+### Mettre à jour les dépendances
+
+Comme la gem `github-pages` est mise à jour régulièrement, il est conseillé de mettre à jour les dépendances (gems) de temps en temps:
+
+```sh
+bundle update
+```
+
+## Documentation utile
+
+* [Jekyll](https://jekyllrb.com/docs/home/), générateur de site statique
+* [Liquid](https://shopify.github.io/liquid/), language de templating utilisé par Jekyll
+* [Github Pages Basics](https://help.github.com/categories/github-pages-basics/)
+* [Customizing Github Pages](https://help.github.com/categories/customizing-github-pages/)

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,7 @@ number_of_season: 3
 plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
+
+whitelist:
+  - jekyll-seo-tag
+  - jekyll-sitemap


### PR DESCRIPTION
Ajoute un README pour documenter l'utilisation de Jekyll localement.
J'encourage à utiliser l'option `--safe` en développement pour être en phase avec le déploiement sur Github Pages.